### PR TITLE
Add metadata to `Job`

### DIFF
--- a/src/Job.php
+++ b/src/Job.php
@@ -37,7 +37,7 @@ class Job implements \JsonSerializable
         if (empty($arr['name']) || !isset($arr['data'])) {
             throw new \InvalidArgumentException('malformed job');
         }
-        $metadata = $arr['metadata'] ?? [];
+        $metadata = isset($arr['metadata']) ? $arr['metadata'] : [];
         return new static($arr['name'], $arr['data'], $metadata);
     }
 

--- a/src/Job.php
+++ b/src/Job.php
@@ -14,15 +14,18 @@ class Job implements \JsonSerializable
 
     public $data;
 
+    public $metadata;
 
-    public function __construct($name, $data)
+
+    public function __construct($name, $data, $metadata = [])
     {
         $this->name = $name;
         $this->data = $data;
+        $this->metadata = $metadata;
     }
 
     /**
-     * Factory to create from ['viewName' => ['name' => $name, 'data' => $data]]
+     * Factory to create from ['viewName' => ['name' => $name, 'data' => $data, 'metadata' => $metadata]]
      *
      * @param array $arr input array
      *
@@ -34,15 +37,16 @@ class Job implements \JsonSerializable
         if (empty($arr['name']) || !isset($arr['data'])) {
             throw new \InvalidArgumentException('malformed job');
         }
-
-        return new static($arr['name'], $arr['data']);
+        $metadata = $arr['metadata'] ?? [];
+        return new static($arr['name'], $arr['data'], $metadata);
     }
 
     public function jsonSerialize()
     {
         return [
             'name' => $this->name,
-            'data' => $this->data
+            'data' => $this->data,
+            'metadata' => $this->metadata
         ];
     }
 }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -43,4 +43,16 @@ class JobTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('my_component', $job->name);
         $this->assertEquals(['some' => 'data'], $job->data);
     }
+
+    /**
+     * @return void
+     */
+    public function testFactoryPopulatesWithMetadata()
+    {
+        $job = \WF\Hypernova\Job::fromArray(['name' => 'my_component', 'data' => ['some' => 'data'], 'metadata' => ['some_other' => 'metadata']]);
+
+        $this->assertEquals('my_component', $job->name);
+        $this->assertEquals(['some' => 'data'], $job->data);
+        $this->assertEquals(['some_other' => 'metadata'], $job->metadata);
+    }
 }


### PR DESCRIPTION
Pass `metadata` into `Job` from request so it can be used in Hypernova server.  This could be useful for data that needs to be passed to the request, but shouldn't actually end up in the component props.