### PR TITLE
Pass metadata to  in renderer

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -235,7 +235,7 @@ class Renderer
         return array_map(function (\WF\Hypernova\Job $job) {
             foreach ($this->plugins as $plugin) {
                 try {
-                    $job = new Job($job->name, $plugin->getViewData($job->name, $job->data));
+                    $job = new Job($job->name, $plugin->getViewData($job->name, $job->data), $job->metadata);
                 } catch (\Exception $e) {
                     $plugin->onError($e, $this->incomingJobs);
                 }

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -65,6 +65,23 @@ class RendererTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('id1', $this->callInternalMethodOfThing($this->renderer, 'createJobs'));
     }
 
+    public function testCreateJobsWithMetadata()
+    {
+        $plugin = $this->createMock(BasePlugin::class);
+
+        $job = ['name' => 'foo', 'data' => ['someData' => []], 'metadata' => ['some_other' => 'foo']];
+
+        $plugin->expects($this->once())
+            ->method('getViewData')
+            ->with($this->equalTo($job['name']), $this->equalTo($job['data']))
+            ->willReturn($job['data']);
+        $this->renderer->addPlugin($plugin);
+        $this->renderer->addJob('id1', $job);
+        $createdJobs = $this->callInternalMethodOfThing($this->renderer, 'createJobs');
+        $this->assertObjectHasAttribute('metadata', $createdJobs['id1']);
+        $this->assertEquals('foo', $createdJobs['id1']->metadata['some_other']);
+    }
+
     public function testMultipleJobsGetCreated()
     {
         $plugin = $this->createMock(BasePlugin::class);


### PR DESCRIPTION
It would be useful to pass `metadata` into the renderer from each job.  This could be used to modify how rendering occurs on a per-job basis.