### PR TITLE
BREAKING: Change prepareRequest to a reducer (#10)

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -245,21 +245,24 @@ class Renderer
     }
 
     /**
-     * @param $jobs
+     * Prepare Request
+     *
+     * @param array $jobs Jobs
+     *
      * @return array
      */
     protected function prepareRequest($jobs)
     {
-        $preparedJobs = array_map(function ($job) {
-            foreach ($this->plugins as $plugin) {
-                $job = $plugin->prepareRequest($job);
-            }
-            return $job;
-        }, $jobs);
+        $preparedJobs = $jobs;
+        foreach ($this->plugins as $plugin) {
+            // Pass both jobs we are working with an original, incoming jobs so
+            // that every plugin has a chance to see _all_ original jobs.
+            $preparedJobs = $plugin->prepareRequest($preparedJobs, $jobs);
+        }
 
         $shouldSend = true;
         foreach ($this->plugins as $plugin) {
-            $shouldSend = $shouldSend && $plugin->shouldSendRequest($jobs);
+            $shouldSend = $shouldSend && $plugin->shouldSendRequest($preparedJobs);
         }
 
         return [$shouldSend, $preparedJobs];

--- a/src/plugins/BasePlugin.php
+++ b/src/plugins/BasePlugin.php
@@ -14,9 +14,9 @@ class BasePlugin implements Plugin
     /**
      * {@inheritdoc}
      */
-    public function prepareRequest($request)
+    public function prepareRequest(array $jobs, array $originalJobs)
     {
-        return $request;
+        return $jobs;
     }
 
     /**

--- a/src/plugins/Plugin.php
+++ b/src/plugins/Plugin.php
@@ -20,10 +20,11 @@ interface Plugin
     public function getViewData($name, array $data);
 
     /**
-     * @param \WF\Hypernova\Job $request
+     * @param \WF\Hypernova\Job[]   $jobs
+     * @param \WF\Hypernova\Job[]   $originalJobs
      * @return \WF\Hypernova\Job
      */
-    public function prepareRequest($request);
+    public function prepareRequest(array $jobs, array $originalJobs);
 
     /**
      * @param \WF\Hypernova\Job[] $jobs

--- a/tests/BasePluginTest.php
+++ b/tests/BasePluginTest.php
@@ -19,8 +19,9 @@ class BasePluginTest extends \PHPUnit\Framework\TestCase
         $plugin = new BasePlugin();
 
         $job = Job::fromArray(['name' => 'foo', 'data' => ['bar' => 'baz']]);
+        $jobs = [$job];
 
-        $this->assertEquals($job, $plugin->prepareRequest($job));
+        $this->assertEquals($jobs, $plugin->prepareRequest($jobs, [$jobs]));
     }
 
     public function testOnError()

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -104,8 +104,8 @@ class RendererTest extends \PHPUnit\Framework\TestCase
 
         $plugin->expects($this->exactly(2))
             ->method('prepareRequest')
-            ->with($this->equalTo($this->defaultJob))
-            ->willReturn($this->defaultJob);
+            ->with($this->equalTo([$this->defaultJob]))
+            ->willReturn([$this->defaultJob]);
 
         $this->renderer->addPlugin($plugin);
         $this->renderer->addPlugin($plugin);
@@ -120,6 +120,9 @@ class RendererTest extends \PHPUnit\Framework\TestCase
         $pluginDontSend = $this->createMock(BasePlugin::class);
         $pluginDoSend = $this->createMock(BasePlugin::class);
 
+        $pluginDoSend->method('prepareRequest')->will($this->returnArgument(0));
+        $pluginDontSend->method('prepareRequest')->will($this->returnArgument(0));
+
         $pluginDontSend->expects($this->once())
             ->method('shouldSendRequest')
             ->willReturn(false);
@@ -130,7 +133,9 @@ class RendererTest extends \PHPUnit\Framework\TestCase
         $this->renderer->addPlugin($pluginDontSend);
         $this->renderer->addPlugin($pluginDoSend);
 
-        $this->assertFalse($this->callInternalMethodOfThing($this->renderer, 'prepareRequest', [[$this->defaultJob]])[0]);
+        $result = $this->callInternalMethodOfThing($this->renderer, 'prepareRequest', [[$this->defaultJob]]);
+        $this->assertEquals([$this->defaultJob], $result[1]);
+        $this->assertFalse($result[0]);
     }
 
     public function testRenderShouldNotSend()


### PR DESCRIPTION
* Change prepareRequest to a reducer

* tweak api, match spec exactly

* typehint prepareRequest

* Revert "typehint prepareRequest"

This reverts commit 79ce3912808f79b6f91dee2414c2fd38d42f40e7.

* naming, fix a few phpcs warnings