### PR TITLE
guzzle updated to 7.2 uuid updated to 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "^6.2",
-        "ramsey/uuid": "^3.5"
+        "guzzlehttp/guzzle": "^7.2",
+        "ramsey/uuid": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
Current Guzzle and UUID versions are outdated and are not compatible with recent versions of the most popular frameworks such as symfony and laravel. This pull requests fixes that.