### PR TITLE
refactor: remove guzzlehttp/guzzle & ramsey/uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "^6.2",
-        "ramsey/uuid": "^3.5"
+        "paragonie/random_compat": ">=1 <9.99"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -1,0 +1,84 @@
+<?php 
+
+namespace WF\Hypernova\Http;
+
+function getOrNull($array, $key){
+    return isset($array[$key]) ? $array[$key] : null;
+}
+
+class Client {
+    private $globalConf;
+
+    public function __construct($conf) {
+        $this->globalConf = $conf;
+    }
+
+    public function request($method, $url, $body = null, $queryParams = null, $headers = []) {
+        $curl = curl_init();
+
+        if (!is_null($queryParams)) {
+            $url .= '?' . http_build_query($queryParams);
+        }
+
+        $conf = array(
+            CURLOPT_URL => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLINFO_HEADER_OUT => true,
+            CURLOPT_ENCODING => '',
+            CURLOPT_MAXREDIRS => 10,
+            CURLOPT_TIMEOUT => 0,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST => $method
+        );
+
+        foreach ($conf as $option => $value) {
+           curl_setopt($curl, $option, $value);
+        }
+
+        if (!is_null($body)) {
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $body);
+        }
+
+        $tmp = [];
+        foreach ($headers as $key => $record) {
+            $tmp[] = $record;
+        }
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $tmp);
+
+        try {
+            $rawResponse = curl_exec($curl);
+        } catch (\ErrorException $ex) {
+            throw new \Exception($ex->getMessage(), $ex->getCode(), $ex->getPrevious());
+        }
+
+        $response = new Response($curl, $rawResponse);
+        curl_close($curl); // close cURL handler
+
+        return $response;
+    }
+
+    public function get($url, $conf = []){
+        $queryParams = getOrNull($conf, 'params');
+        $headers = getOrNull($conf, 'headers');
+        return $this->request('GET', $url, null, $queryParams, $headers);
+    }
+
+    public function post($url, $conf = []) {
+        $body = getOrNull($conf, 'body');
+        $json = getOrNull($conf, 'json');
+        $queryParams = getOrNull($conf, 'params');
+        $headers = getOrNull($conf, 'headers');
+
+        if(!is_null($json)){
+            $body = json_encode($json);
+            if(is_null($headers)) {
+                $headers = [];
+            }
+            $headers[] = "Content-Type: application/json";
+        }
+        return $this->request('POST', $url, $body, $queryParams, $headers);
+    }
+}
+
+?>

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -1,0 +1,43 @@
+<?php 
+
+namespace WF\Hypernova\Http;
+
+class Response {
+
+    private $rawBody;
+    private $headers;
+    private $response;
+
+    public function __construct($curl, $response) {
+        $this->rawBody = $response;
+        if (empty($response)) {
+            throw new Exception("Empty Response", 0);        
+            return;
+        }
+
+        $info = curl_getinfo($curl);
+
+        if (empty($info['http_code'])) {
+            throw new Exception("No HTTP code was returned", 0);        
+            return;
+        }
+
+        $this->response = $info;
+        $this->headers = $info['request_header'];
+
+
+        if($info['http_code'] > 399) {
+            throw new Exception($response, $info['http_code'] );
+        }
+    }
+
+    public function getBody() {
+        return $this->rawBody;
+    }
+
+    public function getHeaders() {
+        return $this->headers;
+    }
+}
+
+?>

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -179,11 +179,11 @@ class Renderer
     }
 
     /**
-     * @return \GuzzleHttp\Client
+     * @return \WF\Hypernova\Http\Client
      */
     protected function getClient()
     {
-        return new \GuzzleHttp\Client($this->config);
+        return new \WF\Hypernova\Http\Client($this->config);
     }
 
     /**
@@ -198,7 +198,7 @@ class Renderer
         $result->error = $topLevelError;
         $result->results = array_map(function (\WF\Hypernova\Job $job) {
             $jobResult = new JobResult();
-            $uuid = \Ramsey\Uuid\Uuid::uuid4();
+            $uuid = random_bytes(16);
             $jobResult->html = $this->getFallbackHTML($job->name, $job->data, $uuid);
             $jobResult->meta = ['uuid' => (string) $uuid];
             $jobResult->originalJob = $job;
@@ -212,7 +212,7 @@ class Renderer
     /**
      * @param string $moduleName
      * @param array $data
-     * @param \Ramsey\Uuid\UuidInterface $uuid
+     * @param string $uuid
      *
      * @return string
      */


### PR DESCRIPTION
With these changes, the need for future maintenance of the library should be reduced.

- Remove guzzlehttp/guzzle and add custom CURL implementation for http request
- Remove  ramsey/uuid for random_compat in >= php7 and use paragonie/random_compat polyfill for random_bytes() in PHP 5.x

